### PR TITLE
Fix typo in Kafka port comment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     image: confluentinc/cp-kafka:latest
     ports:
       - "9092:9092" # Port Kafka
-      - "9093:9093" # Port du contrôleur  KRaft
+      - "9093:9093" # Port du contrôleur KRaft
     environment:
       KAFKA_KRAFT_MODE: "true"
       KAFKA_PROCESS_ROLES: "controller,broker"


### PR DESCRIPTION
## Summary
- correct Kafka comment to use single space before "KRaft"

## Testing
- `sed -n '60,70p' docker-compose.yml`


------
https://chatgpt.com/codex/tasks/task_e_685843c27430832b9aef853be5d74439